### PR TITLE
Correção do link da imagem do wireframe no Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Orientadoras:
 
 ### *Wireframe:* 
 
-Para ver as definições das **páginas**, clique em [aqui]()
+Para ver as definições das **páginas**, clique em [aqui](https://www.dropbox.com/s/oatbftoz3ezqgbv/excalidraw-2020321212841.png?dl=0)
 
 ### *Tecnologias usadas:*
 


### PR DESCRIPTION
Link atual da imagem não estava abrindo. Essa é a correção para o link correto.