### PR TITLE
Tabelas não devem aparecer quando estão vazias

### DIFF
--- a/src/pages/Events/EventsList.js
+++ b/src/pages/Events/EventsList.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { Row, Divider, Button } from 'antd'
+import { Row, Divider, Button, Card } from 'antd'
 import { Link } from 'react-router-dom'
 import TableComponent from '../../components/Table'
 import './events-list.scss'
@@ -34,7 +34,7 @@ const columnsTable = [
         <Link to={`/events/${key}`} onClick={() => localStorage.setItem("idEvent", key)}>Detalhes</Link>
       </span>
     )
-  },  {
+  }, {
     dataIndex: 'id',
     key: 'id',
     render: (key) => (
@@ -63,16 +63,23 @@ const EventsList = () => {
       <Row gutter={[16, 24]}>
         <Divider orientation='left'>
           Meus eventos
-        </Divider>
+  </Divider>
       </Row>
-      <Row justify="end" className='row-table'>
-        <Button type='default'>
-          <Link id="btn-cadastrar" to="/events/form" onClick={() => localStorage.removeItem('idEvent')}><span>Cadastre um evento!</span></Link>
-        </Button>
-      </Row>
-      <Row justify='center' gutter={[16, 24]} className='row-table'>
-        <TableComponent columns={columnsTable} dataSource={api} />
-      </Row>
+      {api.length > 0 ? (
+        <>
+          <Row justify="end" className='row-table'>
+            <Button type='default'>
+              <Link id="btn-cadastrar" to="/events/form" onClick={() => localStorage.removeItem('idEvent')}><span>Cadastre um evento!</span></Link>
+            </Button>
+          </Row>
+          <Row justify='center' gutter={[16, 24]} className='row-table'>
+            <TableComponent columns={columnsTable} dataSource={api} />
+          </Row></>)
+        : (
+          <Row justify="center" className='row-table'>
+            <Card style={{ width: '90%' }}><p>Você ainda não cadastrou nenhum evento</p></Card>
+          </Row>)
+      }
     </>
   )
 }

--- a/src/pages/Lectures/LecturesCSV.js
+++ b/src/pages/Lectures/LecturesCSV.js
@@ -1,39 +1,45 @@
 import React from 'react';
-import { Row, Col, Divider } from 'antd';
+import { Row, Col, Divider, Card } from 'antd';
 import { downloadCSVFromJson } from './../../utils/convertToCSV';
 import { getEnvironment } from './../../utils/environment';
 import { Link } from 'react-router-dom';
 
 const LecturesCSV = () => {
 	const environment = getEnvironment();
+	const userId = localStorage.getItem('userId')
 
-	fetch(`${environment}/lectures`)
+	fetch(`${environment}/lectures?userId=${userId}`)
 		.then((res) => res.json())
 		.then((data) => {
+			// Convertendo arrays em string para não dar problema na hora de converter para csv
+			data.map(lecture => lecture.interests = lecture.interests.toString())
+			data.map(lecture => lecture.activityCategory = lecture.activityCategory.toString())
 			downloadCSVFromJson('palestras.csv', data);
 		})
 		.catch((err) => console.error(err, 'Nenhuma palestra encontrada'));
 
 	return (
 		<div>
-			<Row gutter={[ 16, 24 ]}>
+			<Row gutter={[16, 24]}>
 				<Divider orientation="left">Minhas palestras</Divider>
 			</Row>
 			<Row style={{ marginBottom: 30 }}>
 				<Col span={16} offset={4}>
-					<div className="content-events">
-						<span>O download deverá iniciar automaticamente.</span>
-						<br />
-						<span>Se isso não acontecer, verifique se o navegador não está bloqueando downloads.</span>
-						<br />
-						<span>
-              {' '}Clique{' '}
-              <Link to="/lectures">
-								<span style={{ color: 'black' }}>aqui</span>
-							</Link>
-              {' '}para voltar
+					<Card>
+						<div className="content-events">
+							<span>O download deverá iniciar automaticamente.</span>
+							<br />
+							<span>Se isso não acontecer, verifique se o navegador não está bloqueando downloads.</span>
+							<br />
+							<span>
+								{' '}Clique{' '}
+								<Link to="/lectures">
+									<span style={{ color: 'black' }}>aqui</span>
+								</Link>
+								{' '}para voltar
 						</span>
-					</div>
+						</div>
+					</Card>
 				</Col>
 			</Row>
 		</div>

--- a/src/pages/Lectures/LecturesList.js
+++ b/src/pages/Lectures/LecturesList.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { Row, Divider, Tag, Button, Typography, Spin } from 'antd'
+import { Row, Divider, Tag, Button, Typography, Spin, Card } from 'antd'
 import { Link } from 'react-router-dom'
 import { getEnvironment } from './../../utils/environment'
 import TableComponent from '../../components/Table'
@@ -81,20 +81,20 @@ const LecturesList = () => {
 
   return (
     <>
+    <Row gutter={[16, 24]}>
+              <Divider orientation="left">
+                Minhas palestras
+              </Divider>
+            </Row>
       { loadingData ?
         (
           <Row gutter={[16, 24]}>
             <Spin size='large' />
           </Row>
         )
-          :
+          : lectures.length > 0 ? 
         (
           <>
-            <Row gutter={[16, 24]}>
-              <Divider orientation="left">
-                Minhas palestras
-              </Divider>
-            </Row>
             <Row justify="end" className='row-table'>
               <Button type='default'>
                 <Link to='/download-lectures'><span>Faça o download de suas palestras!</span></Link>
@@ -105,6 +105,9 @@ const LecturesList = () => {
             </Row>
           </>
         )
+        : (<Row justify="center" className='row-table'>
+        <Card style={{ width: '90%' }}><p>Você ainda não cadastrou nenhuma palestra</p></Card>
+      </Row>)
       }
     </>
   )


### PR DESCRIPTION
- Tabelas de eventos e palestras não aparecem quando não há dados cadastrados, em vez disso, aparece uma mensagem de aviso.
- Mesma coisa para o botão de download de palestras
- Também fiz uma correção no csv que estava quebrando pra converter os campos tipo array das palestras (interests e activityCategories)