### PR TITLE
Limitar visualização da plataforma para perfis de usuários

### DIFF
--- a/server.json
+++ b/server.json
@@ -316,19 +316,6 @@
       "interests": []
     },
     {
-      "id": "1613191052178209",
-      "email": "",
-      "localization": "",
-      "registerDate": "2020-04-13",
-      "apresentation": "",
-      "githubLink": "",
-      "linkedinLink": "",
-      "twitterLink": "",
-      "facebookLink": "",
-      "mediumLink": "",
-      "interests": []
-    },
-    {
       "id": "3036218123066022",
       "email": "matancredi@hotmail.com",
       "localization": "Mogi das Cruzes, SP",
@@ -350,6 +337,20 @@
     {
       "id": "2665688483678067",
       "email": "gabrielesuzart@gmail.com",
+      "localization": "",
+      "registerDate": "2020-04-20",
+      "apresentation": "",
+      "githubLink": "",
+      "linkedinLink": "",
+      "twitterLink": "",
+      "facebookLink": "",
+      "mediumLink": "",
+      "interests": []
+    },
+    {
+      "id": "1613191052178209",
+      "role": "Producer",
+      "email": "isabellasoares.contato@hotmail.com",
       "localization": "",
       "registerDate": "2020-04-20",
       "apresentation": "",

--- a/server.json
+++ b/server.json
@@ -304,6 +304,7 @@
   "profiles": [
     {
       "id": "3154754594535841",
+      "role": "Both",
       "email": "",
       "localization": "",
       "registerDate": "2020-04-12",
@@ -317,6 +318,7 @@
     },
     {
       "id": "3036218123066022",
+      "role": "Both",
       "email": "matancredi@hotmail.com",
       "localization": "Mogi das Cruzes, SP",
       "registerDate": "2020-04-15",
@@ -336,6 +338,7 @@
     },
     {
       "id": "2665688483678067",
+      "role": "Both",
       "email": "gabrielesuzart@gmail.com",
       "localization": "",
       "registerDate": "2020-04-20",
@@ -349,7 +352,7 @@
     },
     {
       "id": "1613191052178209",
-      "role": "Producer",
+      "role": "Both",
       "email": "isabellasoares.contato@hotmail.com",
       "localization": "",
       "registerDate": "2020-04-20",

--- a/src/ant_overrides.scss
+++ b/src/ant_overrides.scss
@@ -78,3 +78,25 @@
 .ant-descriptions-item-content {
   font-style: italic !important;
 }
+
+.ant-menu,
+.ant-menu-item {
+  color: #6597EB !important;
+}
+
+.ant-menu-horizontal {
+  border-bottom: 2px solid rgba(0, 0, 0, 0.2) !important;
+
+  .ant-menu-item:hover, .ant-menu-submenu:hover, .ant-menu-item-active,
+  .ant-menu-submenu-active, .ant-menu-item-open, .ant-menu-submenu-open,
+  .ant-menu-item-selected, .ant-menu-submenu-selected {
+    color: #6597EB !important;
+    border-bottom: 2px solid #6597EB !important;
+  }
+
+
+  .ant-menu-item-disabled:hover {
+    color: rgba(0, 0, 0, 0.25) !important;
+    border-bottom: 2px solid transparent !important;
+  }
+}

--- a/src/components/Menu/index.js
+++ b/src/components/Menu/index.js
@@ -11,6 +11,7 @@ const { SubMenu } = Menu
 const HeaderComponent = () => {
   const history = useHistory()
   const userPicture = localStorage.getItem('userPicture');
+  const userRole = localStorage.getItem('userId') ? localStorage.getItem('userRole') : ''
 
   const logout = () => {
     localStorage.clear()
@@ -42,10 +43,16 @@ const HeaderComponent = () => {
           </>)
             :
           (<Menu theme='light' mode='horizontal'>
-            <Menu.Item key='/events' onClick={() => history.push('/events')}>
+            <Menu.Item
+              key='/events'
+              disabled={userRole === 'Speaker'}
+              onClick={() => history.push('/events')}>
               Sou produtor de eventos
             </Menu.Item>
-            <Menu.Item key='/lectures' onClick={() => history.push('/lectures')}>
+            <Menu.Item
+              key='/lectures'
+              disabled={userRole === 'Producer'}
+              onClick={() => history.push('/lectures')}>
               Sou palestrante
             </Menu.Item>
             <SubMenu title={<Avatar src={userPicture} />}>

--- a/src/components/Menu/style.scss
+++ b/src/components/Menu/style.scss
@@ -10,64 +10,47 @@
   float: left;
   padding-top: 5px;
 
-    @media (orientation: portrait) {
-      display: none;
-    }
+  @media (orientation: portrait) {
+    display: none;
   }
+}
 
-  .logo-mobile {
-    width: 50px;
-    float: left;
-    padding-top: 5px;
+.logo-mobile {
+  width: 50px;
+  float: left;
+  padding-top: 5px;
 
-    @media (orientation: landscape) {
-      display: none;
-    }
+  @media (orientation: landscape) {
+    display: none;
   }
+}
 
 
-  .anticon {
-    font-size: 15px;
+.anticon {
+  font-size: 15px;
+}
+
+.logo-mobile {
+  width: 50px;
+  float: left;
+  padding-top: 5px;
+
+  @media (orientation: landscape) {
+    display: none;
   }
+}
 
-  .logo-mobile {
-    width: 50px;
-    float: left;
-    padding-top: 5px;
+.menu {
+  display: flex;
+  align-items: center;
+  float: right;
+  height: inherit;
+}
 
-    @media (orientation: landscape) {
-      display: none;
-    }
-  }
+.menu button {
+  margin-left: 2em;
+}
 
-  .menu {
-    display: flex;
-    align-items: center;
-    float: right;
-    height: inherit;
-  }
-
-  .menu button {
-    margin-left: 2em;
-  }
-
-  .ant-menu,
-  .ant-menu-item {
-    color: #6597EB !important;
-  }
-
-  .ant-menu-horizontal {
-    border-bottom: 2px solid rgba(0, 0, 0, 0.2) !important;
-
-    .ant-menu-item:hover, .ant-menu-submenu:hover, .ant-menu-item-active,
-    .ant-menu-submenu-active, .ant-menu-item-open, .ant-menu-submenu-open,
-    .ant-menu-item-selected, .ant-menu-submenu-selected {
-      color: #6597EB !important;
-      border-bottom: 2px solid #6597EB !important;
-    }
-  }
-
-  .svg-inline--fa {
-    margin-right: 0.5em;
-  }
-
+.svg-inline--fa {
+  margin-right: 0.5em;
+}

--- a/src/pages/Login/FBLogin.js
+++ b/src/pages/Login/FBLogin.js
@@ -4,7 +4,7 @@ import FacebookLogin from 'react-facebook-login'
 import { getCurrentDate } from './../../utils/currentDate'
 import { getEnvironment } from './../../utils/environment'
 
-const FBLogin = ({ isDisabled }) => {
+const FBLogin = ({ isDisabled, role }) => {
   let history = useHistory()
   const environment = getEnvironment()
 
@@ -25,6 +25,7 @@ const FBLogin = ({ isDisabled }) => {
         if (!data.find((profile) => profile.email === response.email)) {
           let newProfile = {
             id: response.userID,
+            role: role,
             email: response.email? response.email : '',
             localization: '',
             registerDate: `${getCurrentDate()}`,

--- a/src/pages/Login/FBLogin.js
+++ b/src/pages/Login/FBLogin.js
@@ -14,6 +14,7 @@ const FBLogin = ({ isDisabled, role }) => {
     localStorage.setItem('userPicture', response.picture.data.url)
     localStorage.setItem('userName', response.name)
     localStorage.setItem('userEmail', response.email)
+    localStorage.setItem('userRole', role)
 
     // Redireciona para a página inicial
     history.push('/')

--- a/src/pages/Login/index.js
+++ b/src/pages/Login/index.js
@@ -53,7 +53,7 @@ const Login = () => {
         </Card>
       </Row>
       <Row gutter={[16, 24]} className='btn-group' justify='center'>
-        <FBLogin isDisabled={role === ''} />
+        <FBLogin isDisabled={role === ''} role={role} />
         <Button type='primary' className='google-button' disabled>
           <FontAwesomeIcon icon={faGoogle} />
           Continuar com o Google

--- a/src/pages/Login/style.scss
+++ b/src/pages/Login/style.scss
@@ -12,6 +12,10 @@
     &:hover {
       opacity: 0.8;
     }
+
+    &:disabled {
+      opacity: 0.5;
+    }
   }
 
   .facebook-button {

--- a/src/pages/Profile/ProfileDescription.js
+++ b/src/pages/Profile/ProfileDescription.js
@@ -11,7 +11,18 @@ import './style.scss'
 
 const { Item } = Descriptions;
 
-const ProfileDescription = ({ profile, userEmail }) => {
+const ProfileDescription = ({ profile }) => {
+
+  const getUserRole = (role) => {
+    if (role === 'Producer') {
+      return 'Produtor de eventos'
+    } else if (role === 'Speaker') {
+      return 'Palestrante'
+    }
+
+    return 'Produtor de eventos e palestrante'
+  }
+
   return (
     <Descriptions layout="vertical">
       <Item label="Apresentação" span={3}>
@@ -22,6 +33,9 @@ const ProfileDescription = ({ profile, userEmail }) => {
       </Item>
       <Item label="Interesses" span={3}>
         {profile.interests ? profile.interests && profile.interests.map(item => <Tag style={{ marginBottom: '8px' }} key={item}>{item}</Tag>) : "Sem dados"}
+      </Item>
+      <Item label="Quem sou eu" span={1}>
+        { getUserRole(profile.role) }
       </Item>
       <Item label="Data de cadastro" span={1}>
         {profile.registerDate? `${(profile.registerDate)}` : 'Sem dados'}

--- a/src/pages/Profile/ProfileForm.js
+++ b/src/pages/Profile/ProfileForm.js
@@ -56,7 +56,8 @@ const ProfileForm = () => {
 			})
 				.then((response) => {
 					response.json().then((response) => {
-						console.log('Perfil atualizado com sucesso')
+            console.log('Perfil atualizado com sucesso')
+            localStorage.setItem('userRole', values.role)
 						history.push('/profile')
 					})
 				})

--- a/src/pages/Profile/ProfileForm.js
+++ b/src/pages/Profile/ProfileForm.js
@@ -3,7 +3,6 @@ import { useFormik } from 'formik'
 import { useHistory } from 'react-router-dom'
 import { getEnvironment } from './../../utils/environment'
 import { Form, Input, Row, Col, Button, Divider, Radio } from 'antd'
-// import {  } from 'formik-antd'
 import './style.scss'
 
 const ProfileForm = () => {

--- a/src/pages/Profile/ProfileForm.js
+++ b/src/pages/Profile/ProfileForm.js
@@ -9,7 +9,7 @@ const ProfileForm = () => {
 	let history = useHistory()
 	const environment = getEnvironment()
   const [ profile, setProfile ] = useState([])
-  const [radio, setValuesRadio] = useState('')
+  const [radio, setRadio] = useState('')
 
 	useEffect(() => {
 		fetch(`${environment}/profiles`)
@@ -21,7 +21,7 @@ const ProfileForm = () => {
   }, [environment])
 
   const onChangeRole = (role) => {
-    setValuesRadio(role.target.value)
+    setRadio(role.target.value)
     formik.values.role = role.target.value
   }
 

--- a/src/pages/Profile/ProfileForm.js
+++ b/src/pages/Profile/ProfileForm.js
@@ -2,13 +2,15 @@ import React, { useState, useEffect } from 'react'
 import { useFormik } from 'formik'
 import { useHistory } from 'react-router-dom'
 import { getEnvironment } from './../../utils/environment'
-import { Form, Input, Row, Col, Button, Divider } from 'antd'
+import { Form, Input, Row, Col, Button, Divider, Radio } from 'antd'
+// import {  } from 'formik-antd'
 import './style.scss'
 
 const ProfileForm = () => {
 	let history = useHistory()
 	const environment = getEnvironment()
-	const [ profile, setProfile ] = useState([])
+  const [ profile, setProfile ] = useState([])
+  const [radio, setValuesRadio] = useState('')
 
 	useEffect(() => {
 		fetch(`${environment}/profiles`)
@@ -17,7 +19,12 @@ const ProfileForm = () => {
 				setProfile(data.find((profile) => profile.id === localStorage.getItem('userId')))
 			})
 			.catch((err) => console.error(err, 'Nenhum usuário encontrado'))
-	}, [environment])
+  }, [environment])
+
+  const onChangeRole = (role) => {
+    setValuesRadio(role.target.value)
+    formik.values.role = role.target.value
+  }
 
 	let formik = useFormik({
 		initialValues: profile,
@@ -33,7 +40,8 @@ const ProfileForm = () => {
 					'Content-Type': 'application/json'
 				},
 				body: JSON.stringify({
-					id: values.id,
+          id: values.id,
+          role: values.role,
 					email: values.email,
 					localization: values.localization,
 					registerDate: values.registerDate,
@@ -68,6 +76,17 @@ const ProfileForm = () => {
 			<Row gutter={[16, 24]}>
 				<Col span={14} offset={5}>
 					<Form onFinish={formik.handleSubmit} layout='vertical'>
+            <Form.Item
+              label="Quem é você ?"
+              htmlFor="role"
+              rules={[{ required: true }]}>
+              <Radio.Group name="role" onChange={onChangeRole}>
+                <Radio value={'Producer'} checked={formik.values.role === 'Producer'}>Produtor de eventos</Radio>
+                <Radio value={'Speaker'} checked={formik.values.role === 'Speaker'}>Palestrante</Radio>
+                <Radio value={'Both'} checked={formik.values.role === 'Both'}>Ambos</Radio>
+              </Radio.Group>
+            </Form.Item>
+
 						<Form.Item label='Apresentação'>
 							<Input.TextArea
 								rows={4}


### PR DESCRIPTION
# Título do PR

Limitar visualização da plataforma para perfis de usuários

## Descrição do PR

- Enviar role do usuário para a API após o login
- Limitar as visualizações da plataforma de acordo com a role do usuário
- Permitir a edição do perfil de usuário no Formulário de Perfil

## Capturas de Tela

- Tela de perfil com tipo de perfil

![image](https://user-images.githubusercontent.com/32148199/79777143-34b03c80-830d-11ea-99b8-64e16621d384.png)

- Edição de tipo de perfil

![image](https://user-images.githubusercontent.com/32148199/79777280-63c6ae00-830d-11ea-918a-8421670cd8f3.png)

- Aba desabilitada para o perfil "Produtor de eventos"

![image](https://user-images.githubusercontent.com/32148199/79777346-7c36c880-830d-11ea-8fc3-6fc4d93b8878.png)

## Issue do repo

Issue #163 
