### PR TITLE
Novo layout para página de eventos e palestras sem cadastros

### DIFF
--- a/src/pages/Events/EventsList.js
+++ b/src/pages/Events/EventsList.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { Row, Button, Card } from 'antd'
-import { Link } from 'react-router-dom'
+import { Link, useHistory } from 'react-router-dom'
 import TableComponent from '../../components/Table'
 import './events-list.scss'
 
@@ -47,6 +47,7 @@ const columnsTable = [
 ]
 const EventsList = () => {
   const [api, setApi] = useState([])
+  const history = useHistory()
 
   const environment = getEnvironment();
 
@@ -61,10 +62,9 @@ const EventsList = () => {
 
   return (
     <>
-      <Header text="Meus eventos" />
-
       {api.length > 0 ? (
         <>
+          <Header text="Meus eventos" />
           <Row justify="end" className='row-table'>
             <Button type='default'>
               <Link id="btn-cadastrar" to="/events/form" onClick={() => localStorage.removeItem('idEvent')}><span>Cadastre um evento!</span></Link>
@@ -72,11 +72,15 @@ const EventsList = () => {
           </Row>
           <Row justify='center' gutter={[16, 24]} className='row-table'>
             <TableComponent columns={columnsTable} dataSource={api} />
-          </Row></>)
-        : (
-          <Row justify="center" className='row-table'>
-            <Card style={{ width: '90%' }}><p>Você ainda não cadastrou nenhum evento</p></Card>
-          </Row>)
+          </Row>
+        </>)
+          :
+        (<Row justify="center" className='empty-box'>
+          <Card>
+            <p>Você ainda não possui eventos!</p>
+            <Button type='default' className='login-btn' onClick={() => history.push('/events/form')}>Cadastrar um novo evento</Button>
+          </Card>
+        </Row>)
       }
     </>
   )

--- a/src/pages/Events/events-list.scss
+++ b/src/pages/Events/events-list.scss
@@ -1,3 +1,26 @@
 .ant-table-middle .ant-table-thead > tr > th {
   padding-right: 35px;
 }
+
+.empty-box {
+  margin: 5em auto !important;
+  width: 50%;
+
+  .ant-card {
+    width: 100%;
+  }
+
+  .ant-card-body {
+    padding: 75px;
+    text-align: center;
+  }
+
+  button, p {
+    font-weight: bold;
+  }
+
+  p {
+    font-size: 16px;
+    margin-bottom: 2em;
+  }
+}


### PR DESCRIPTION
# Título do PR

Novo layout para página de eventos e palestras sem cadastros

## Descrição do PR

- Melhorias no layout da tela de eventos quando não há eventos cadastrados
- Adicionei um botão que redireciona para o formulário de cadastros de eventos
- Melhorias no layout da tela de palestras quando não há palestras cadastrados
- Adicionei um botão que redireciona para o formulário de cadastros de palestras

## Capturas de Tela

- Antes (Eventos)

![image](https://user-images.githubusercontent.com/32148199/79896959-67c30080-83df-11ea-89ef-5a4b544fd36d.png)

- Depois (Eventos)

![Sem título](https://user-images.githubusercontent.com/32148199/79897203-be303f00-83df-11ea-92bf-13eca6f44a04.png)

- Antes (Palestras)

![Sem título](https://user-images.githubusercontent.com/32148199/79898842-4a436600-83e2-11ea-86d9-4e6cad21f5c2.png)

- Depois (Palestras)

![Sem título](https://user-images.githubusercontent.com/32148199/79898825-43b4ee80-83e2-11ea-9baa-7acce13ad0db.png)

## Issue do repo

Issue #172 