### PR TITLE
Novo layout para página de eventos e palestras sem cadastros

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -34,6 +34,7 @@ const Routes = props => (
 
       <Route exact path="/lectures" component={routerProps => <LecturesList {...routerProps} />} />
       <Route exact path="/download-lectures" component={routerProps => <DownloadLectures {...routerProps} />} />
+      <Route exact path="/lectures/form" component={routerProps => <LectureForm {...routerProps} />} />
       <Route exact path="/lectures/form/:eventId" component={routerProps => <LectureForm {...routerProps} />} />
       <Route path="/lectures/:lectureId" component={routerProps => <Lecture {...routerProps} />} />
 

--- a/src/components/Menu/style.scss
+++ b/src/components/Menu/style.scss
@@ -1,10 +1,3 @@
-.login-btn {
-  &:hover {
-    background-color: #6999EB;
-    color: white !important;
-  }
-}
-
 .logo {
   width: 270px;
   float: left;

--- a/src/index.scss
+++ b/src/index.scss
@@ -39,3 +39,33 @@ h3 {
   color: red;
   margin: 0 5px 0 5px;
 }
+
+.empty-box {
+  margin: 5em auto !important;
+  width: 50%;
+
+  .ant-card {
+    width: 100%;
+  }
+
+  .ant-card-body {
+    padding: 75px;
+    text-align: center;
+  }
+
+  button, p {
+    font-weight: bold;
+  }
+
+  p {
+    font-size: 16px;
+    margin-bottom: 2em;
+  }
+}
+
+.login-btn {
+  &:hover {
+    background-color: #6999EB !important;
+    color: white !important;
+  }
+}

--- a/src/pages/Events/EventsList.js
+++ b/src/pages/Events/EventsList.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { Row, Button, Card } from 'antd'
-import { Link } from 'react-router-dom'
+import { Link, useHistory } from 'react-router-dom'
 import TableComponent from '../../components/Table'
 import './events-list.scss'
 
@@ -47,6 +47,7 @@ const columnsTable = [
 ]
 const EventsList = () => {
   const [api, setApi] = useState([])
+  const history = useHistory()
 
   const environment = getEnvironment();
 
@@ -61,10 +62,9 @@ const EventsList = () => {
 
   return (
     <>
-      <Header text="Meus eventos" />
-
       {api.length > 0 ? (
         <>
+          <Header text="Meus eventos" />
           <Row justify="end" className='row-table'>
             <Button type='default'>
               <Link id="btn-cadastrar" to="/events/form" onClick={() => localStorage.removeItem('idEvent')}><span>Cadastre um evento!</span></Link>
@@ -72,11 +72,15 @@ const EventsList = () => {
           </Row>
           <Row justify='center' gutter={[16, 24]} className='row-table'>
             <TableComponent columns={columnsTable} dataSource={api} />
-          </Row></>)
-        : (
-          <Row justify="center" className='row-table'>
-            <Card style={{ width: '90%' }}><p>Você ainda não cadastrou nenhum evento</p></Card>
-          </Row>)
+          </Row>
+        </>)
+          :
+        (<Row justify="center" className='empty-box'>
+          <Card>
+            <p>Você ainda não possui eventos!</p>
+            <Button type='default' className='login-btn' onClick={() => history.push('/events/form')}>Cadastrar um novo evento</Button>
+          </Card>
+        </Row>)
       }
     </>
   )

--- a/src/pages/Events/EventsList.js
+++ b/src/pages/Events/EventsList.js
@@ -78,7 +78,12 @@ const EventsList = () => {
         (<Row justify="center" className='empty-box'>
           <Card>
             <p>Você ainda não possui eventos!</p>
-            <Button type='default' className='login-btn' onClick={() => history.push('/events/form')}>Cadastrar um novo evento</Button>
+            <Button
+              type='default'
+              className='login-btn'
+              onClick={() => history.push('/events/form')}>
+                Cadastrar um novo evento
+            </Button>
           </Card>
         </Row>)
       }

--- a/src/pages/Events/EventsList.js
+++ b/src/pages/Events/EventsList.js
@@ -73,9 +73,9 @@ const EventsList = () => {
           <Row justify='center' gutter={[16, 24]} className='row-table'>
             <TableComponent columns={columnsTable} dataSource={api} />
           </Row>
-        </>)
-          :
-        (<Row justify="center" className='empty-box'>
+        </>
+        ) : (
+        <Row justify="center" className='empty-box'>
           <Card>
             <p>Você ainda não possui eventos!</p>
             <Button

--- a/src/pages/Events/events-list.scss
+++ b/src/pages/Events/events-list.scss
@@ -1,3 +1,26 @@
 .ant-table-middle .ant-table-thead > tr > th {
   padding-right: 35px;
 }
+
+.empty-box {
+  margin: 5em auto !important;
+  width: 50%;
+
+  .ant-card {
+    width: 100%;
+  }
+
+  .ant-card-body {
+    padding: 75px;
+    text-align: center;
+  }
+
+  button, p {
+    font-weight: bold;
+  }
+
+  p {
+    font-size: 16px;
+    margin-bottom: 2em;
+  }
+}

--- a/src/pages/Events/events-list.scss
+++ b/src/pages/Events/events-list.scss
@@ -1,26 +1,3 @@
 .ant-table-middle .ant-table-thead > tr > th {
   padding-right: 35px;
 }
-
-.empty-box {
-  margin: 5em auto !important;
-  width: 50%;
-
-  .ant-card {
-    width: 100%;
-  }
-
-  .ant-card-body {
-    padding: 75px;
-    text-align: center;
-  }
-
-  button, p {
-    font-weight: bold;
-  }
-
-  p {
-    font-size: 16px;
-    margin-bottom: 2em;
-  }
-}

--- a/src/pages/Lectures/LecturesList.js
+++ b/src/pages/Lectures/LecturesList.js
@@ -102,9 +102,8 @@ const LecturesList = () => {
               <TableComponent columns={columnsTable} dataSource={ loadingData ? [] : lectures } />
             </Row>
           </>
-        )
-          :
-        (<Row justify="center" className='empty-box'>
+        ) : (
+        <Row justify="center" className='empty-box'>
           <Card>
             <p>Você ainda não possui palestras!</p>
             <Button

--- a/src/pages/Lectures/LecturesList.js
+++ b/src/pages/Lectures/LecturesList.js
@@ -102,7 +102,7 @@ const LecturesList = () => {
               <TableComponent columns={columnsTable} dataSource={ loadingData ? [] : lectures } />
             </Row>
           </>
-        )
+        ) : (
           :
         (<Row justify="center" className='empty-box'>
           <Card>

--- a/src/pages/Lectures/LecturesList.js
+++ b/src/pages/Lectures/LecturesList.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { Row, Tag, Button, Typography, Spin, Card } from 'antd'
-import { Link } from 'react-router-dom'
+import { Link, useHistory } from 'react-router-dom'
 import { getEnvironment } from './../../utils/environment'
 import TableComponent from '../../components/Table'
 import './lectures-list.scss'
@@ -67,6 +67,7 @@ const LecturesList = () => {
   const [ lectures, setLectures ] = useState([])
   const [ loadingData, setLoadingData ] = useState(true)
   const environment = getEnvironment()
+  const history = useHistory()
   const userId = localStorage.getItem('userId')
 
   useEffect(() => {
@@ -82,16 +83,16 @@ const LecturesList = () => {
 
   return (
     <>
-      <Header text="Minhas palestras" />
       { loadingData ?
         (
           <Row gutter={[16, 24]}>
             <Spin size='large' />
           </Row>
         )
-          : lectures.length > 0 ?
+        : lectures.length > 0 ?
         (
           <>
+            <Header text="Minhas palestras" />
             <Row justify="end" className='row-table'>
               <Button type='default'>
                 <Link to='/download-lectures'><span>Faça o download de suas palestras!</span></Link>
@@ -102,9 +103,18 @@ const LecturesList = () => {
             </Row>
           </>
         )
-        : (<Row justify="center" className='row-table'>
-        <Card style={{ width: '90%' }}><p>Você ainda não cadastrou nenhuma palestra</p></Card>
-      </Row>)
+          :
+        (<Row justify="center" className='empty-box'>
+          <Card>
+            <p>Você ainda não possui palestras!</p>
+            <Button
+              type='default'
+              className='login-btn'
+              onClick={() => history.push('/lectures/form')}>
+                Cadastrar uma nova palestra
+            </Button>
+          </Card>
+        </Row>)
       }
     </>
   )


### PR DESCRIPTION
# Título do PR

Novo layout para página de eventos e palestras sem cadastros

## Descrição do PR

- Melhorias no layout da tela de eventos quando não há eventos cadastrados
- Adicionei um botão que redireciona para o formulário de cadastros de eventos
- Melhorias no layout da tela de palestras quando não há palestras cadastrados
- Adicionei um botão que redireciona para o formulário de cadastros de palestras

## Capturas de Tela

- Antes (Eventos)

![image](https://user-images.githubusercontent.com/32148199/79896959-67c30080-83df-11ea-89ef-5a4b544fd36d.png)

- Depois (Eventos)

![Sem título](https://user-images.githubusercontent.com/32148199/79897203-be303f00-83df-11ea-92bf-13eca6f44a04.png)

- Antes (Palestras)

![Sem título](https://user-images.githubusercontent.com/32148199/79898842-4a436600-83e2-11ea-86d9-4e6cad21f5c2.png)

- Depois (Palestras)

![Sem título](https://user-images.githubusercontent.com/32148199/79898825-43b4ee80-83e2-11ea-9baa-7acce13ad0db.png)

## Issue do repo

Issue #172 