### PR TITLE
Correção do botão de criar nova palestra na página do palestrante

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -60,6 +60,10 @@ h3 {
   p {
     font-size: 16px;
     margin-bottom: 2em;
+
+    &:first-child {
+      margin-bottom: 1em;
+    }
   }
 }
 

--- a/src/pages/Lectures/LectureForm.js
+++ b/src/pages/Lectures/LectureForm.js
@@ -85,12 +85,16 @@ const LectureForm = () => {
 		return (
 			<>
 			<Header text="Submissão de atividades" />
-			<Row justify="center" style={{ marginBottom: 20 }}>
-				Para participar, preencha o formulário e aguarde o contato da equipe organizadora do evento&nbsp;<strong> {`${event.event}`} </strong>
-			</Row>
-			<Row justify="center" style={{ marginBottom: 20 }}>
-				Clique&nbsp;<Link to={`/lectures/copylecture/${eventId}`}>aqui</Link>&nbsp;para reaproveitar uma palestra já submetida em outro evento
-			</Row>
+      { event ?
+        (<>
+          <Row justify="center" style={{ marginBottom: 20 }}>
+            Para participar, preencha o formulário e aguarde o contato da equipe organizadora do evento&nbsp;<strong> {`${event.event}`} </strong>
+          </Row>
+          <Row justify="center" style={{ marginBottom: 20 }}>
+            Clique&nbsp;<Link to={`/lectures/copylecture/${eventId}`}>aqui</Link>&nbsp;para reaproveitar uma palestra já submetida em outro evento
+          </Row>
+        </>) : (<></>)
+      }
 			<Row justify="center" className="row-table">
 				<Formik
 					initialValues={profile}

--- a/src/pages/Lectures/LecturesList.js
+++ b/src/pages/Lectures/LecturesList.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { Row, Tag, Button, Typography, Spin, Card } from 'antd'
+import { Row, Tag, Button, Typography, Card } from 'antd'
 import { Link, useHistory } from 'react-router-dom'
 import { getEnvironment } from './../../utils/environment'
 import TableComponent from '../../components/Table'
@@ -65,7 +65,6 @@ const columnsTable = [
 
 const LecturesList = () => {
   const [ lectures, setLectures ] = useState([])
-  const [ loadingData, setLoadingData ] = useState(true)
   const environment = getEnvironment()
   const history = useHistory()
   const userId = localStorage.getItem('userId')
@@ -74,47 +73,37 @@ const LecturesList = () => {
     fetch(`${environment}/lectures`)
       .then(res => res.json())
       .then(data => {
-        let filter = data.filter(lecture => lecture.userId === userId)
+        let filter = data.filter(lecture => lecture.userId === Number(userId))
         setLectures(filter)
       })
-      .then(setLoadingData(false))
       .catch(err => console.error(err, 'Nenhum usuário encontrado'))
   }, [environment, userId])
 
   return (
     <>
-      { loadingData ?
-        (
-          <Row gutter={[16, 24]}>
-            <Spin size='large' />
-          </Row>
-        )
-        : lectures.length > 0 ?
-        (
-          <>
-            <Header text="Minhas palestras" />
-            <Row justify="end" className='row-table'>
-              <Button type='default'>
-                <Link to='/download-lectures'><span>Faça o download de suas palestras!</span></Link>
-              </Button>
-            </Row>
-            <Row justify="center" className='row-table'>
-              <TableComponent columns={columnsTable} dataSource={ loadingData ? [] : lectures } />
-            </Row>
-          </>
-        ) : (
-        <Row justify="center" className='empty-box'>
-          <Card>
-            <p>Você ainda não possui palestras!</p>
-            <p>Dê uma olhada nos nossos eventos e cadastre sua palestra!</p>
-            <Button
-              type='default'
-              className='login-btn'
-              onClick={() => history.push('/')}>
-                Cadastrar uma nova palestra
+      { lectures.length > 0 ?
+        (<>
+          <Header text="Minhas palestras" />
+          <Row justify="end" className='row-table'>
+            <Button type='default'>
+              <Link to='/download-lectures'><span>Faça o download de suas palestras!</span></Link>
             </Button>
-          </Card>
-        </Row>)
+          </Row>
+          <Row justify="center" className='row-table'>
+            <TableComponent columns={columnsTable} dataSource={ lectures } />
+          </Row>
+        </>) : (
+          <Row justify="center" className='empty-box'>
+            <Card>
+              <p>Você ainda não possui palestras!</p>
+              <Button
+                type='default'
+                className='login-btn'
+                onClick={() => history.push('/lectures/form')}>
+                  Cadastrar uma nova palestra
+              </Button>
+            </Card>
+          </Row>)
       }
     </>
   )

--- a/src/pages/Lectures/LecturesList.js
+++ b/src/pages/Lectures/LecturesList.js
@@ -106,10 +106,11 @@ const LecturesList = () => {
         <Row justify="center" className='empty-box'>
           <Card>
             <p>Você ainda não possui palestras!</p>
+            <p>Dê uma olhada nos nossos eventos e cadastre sua palestra!</p>
             <Button
               type='default'
               className='login-btn'
-              onClick={() => history.push('/lectures/form')}>
+              onClick={() => history.push('/')}>
                 Cadastrar uma nova palestra
             </Button>
           </Card>

--- a/src/pages/Lectures/lectures-list.scss
+++ b/src/pages/Lectures/lectures-list.scss
@@ -3,7 +3,7 @@
 }
 
 .status-cell {
-  text-align: center;
+  text-align: center !important;
 }
 
 .status-cell span {


### PR DESCRIPTION
# Título do PR

Correção do botão de criar nova palestra na página do palestrante

## Descrição do PR

O botão de "Cadastrar nova palestra" na home do palestrante deve permitir que o usuário crie uma palestra sem um evento associado.

## Issue do repo

Issue  #186 
