### PR TITLE
Melhoria de layout - detalhe do evento

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -13,7 +13,7 @@ const Header = ({ text }) => {
 }
 
 Header.propTypes = {
-  text: PropTypes.string.isRequired,
+  text: PropTypes.string,
 }
 
 export default Header

--- a/src/components/Menu/index.js
+++ b/src/components/Menu/index.js
@@ -43,7 +43,7 @@ const HeaderComponent = () => {
                   Destaques
                 </Menu.Item>
               </Menu>
-              <Button type='default' className='login-btn' onClick={() => history.push('/login')}>Login</Button>
+              <Button type='default' className='btn-outline' onClick={() => history.push('/login')}>Login</Button>
             </>)
               :
             (<Menu theme='light' mode='horizontal'>

--- a/src/index.scss
+++ b/src/index.scss
@@ -63,7 +63,7 @@ h3 {
   }
 }
 
-.login-btn {
+.btn-outline {
   &:hover {
     background-color: #6999EB !important;
     color: white !important;

--- a/src/pages/Events/EventsList.js
+++ b/src/pages/Events/EventsList.js
@@ -80,7 +80,7 @@ const EventsList = () => {
             <p>Você ainda não possui eventos!</p>
             <Button
               type='default'
-              className='login-btn'
+              className='btn-outline'
               onClick={() => history.push('/events/form')}>
                 Cadastrar um novo evento
             </Button>

--- a/src/pages/Lectures/LecturesList.js
+++ b/src/pages/Lectures/LecturesList.js
@@ -108,7 +108,7 @@ const LecturesList = () => {
             <p>Você ainda não possui palestras!</p>
             <Button
               type='default'
-              className='login-btn'
+              className='btn-outline'
               onClick={() => history.push('/lectures/form')}>
                 Cadastrar uma nova palestra
             </Button>


### PR DESCRIPTION
# Melhoria de layout - detalhe do evento

## Descrição do PR

Melhorias no layout da descrição do evento

## Capturas de Tela

![image](https://user-images.githubusercontent.com/30198542/79945022-557aae00-8443-11ea-9c02-bf31ec7d9b96.png)
![image](https://user-images.githubusercontent.com/30198542/79945046-65928d80-8443-11ea-88d5-b8bb16802e08.png)

## Issue do repo

https://github.com/React-Bootcamp-WoMarkersCode/call-of-papers/issues/170

## Casos de Teste Pensados

- [ ] Testei o fluxo para o evento quando é do proprio produtor de eventos
- [ ] Testei o fluxo para o evento quando um potencial palestrante entra

## Descrição técnica da solução

Usei 4 colunas off de cada lado, o conteúdo 16 colunas.
Criei a função `getUserIsOwner` para checar se quem está logado é o dono do evento que está aberto na tela, para ser usado em outros lugares da aplicação, o ideal é transforma-lo em helper.

## Dilemas, dúvidas e dívidas

Espaço limitado e parceiros aceitos, são informaçōes que eu não considero relevantes, ou pelo menos não entendi a finalidade delas. Acredito que dá para remove-las.
Sobre o espaço ser limitado, todos os espaços são limitados!! O que poderia perguntar ao invés disso é (O evento é presencial ou online?) 
Sobre parceiros aceitos, ninguém limita o tipo de parceiros, toda ajuda de custo é bem vinda independente de onde vem. O que poderia pedir é a url do site dos parceiros e logo para serem exibidas na plataforma. (o que pode deixar para outro momento se não der tempo), mas acho bom tirar a pergunta do form porque tá estranha.

Falta substituir imagem fake por uma imagem que o usuário vai passar a url