### PR TITLE
Desabilitar abas do menu de acordo com o perfil do usuário

### DIFF
--- a/src/components/Menu/index.js
+++ b/src/components/Menu/index.js
@@ -47,10 +47,16 @@ const HeaderComponent = () => {
             </>)
               :
             (<Menu theme='light' mode='horizontal'>
-              <Menu.Item key='/events' onClick={() => history.push('/events')}>
+              <Menu.Item
+                key='/events'
+                disabled={userRole === 'Speaker'}
+                onClick={() => history.push('/events')}>
                 Sou produtor de eventos
               </Menu.Item>
-              <Menu.Item key='/lectures' onClick={() => history.push('/lectures')}>
+              <Menu.Item
+                key='/lectures'
+                disabled={userRole === 'Producer'}
+                onClick={() => history.push('/lectures')}>
                 Sou palestrante
               </Menu.Item>
               <SubMenu title={<Avatar src={userPicture} />}>


### PR DESCRIPTION
# Título do PR

Desabilitar abas do menu de acordo com o perfil do usuário

## Descrição do PR

Adicionei a verificação do campo `userRole` para desabilitar as abas do menu de acordo com a mudança de perfil do usuário. Essa melhoria já havia sido feita na PR #164 , porém deve ter sido sobrescrita por algum merge.

## Issue do repo

Issue #192 
