### PR TITLE
Correção: footer responsivo

### DIFF
--- a/src/ant_overrides.scss
+++ b/src/ant_overrides.scss
@@ -37,8 +37,8 @@
     .ant-row {
       justify-content: center !important;
 
-      div:nth-child(2) {
-        margin-top: 0.5em;
+      .ant-space-horizontal {
+        margin-top: 0.5em !important;
       }
     }
   }

--- a/src/ant_overrides.scss
+++ b/src/ant_overrides.scss
@@ -29,6 +29,19 @@
   padding: 15px 50px !important;
   display: flex !important;
   justify-content: space-evenly !important;
+
+  @media (max-width: 425px) {
+    font-size: 12px !important;
+    padding: 10px 30px !important;
+
+    .ant-row {
+      justify-content: center !important;
+
+      div:nth-child(2) {
+        margin-top: 0.5em;
+      }
+    }
+  }
 }
 
 .ant-divider-inner-text {


### PR DESCRIPTION
# Título do PR

Correção: footer responsivo

## Descrição do PR

- Ajustei o footer para ficar responsivo em telas mobile (menores que 425px)

## Capturas de Tela

- Antes

![antes](https://user-images.githubusercontent.com/32148199/80049280-d2139800-84e8-11ea-8e17-8650a1af48d1.png)

- Depois

![depois 1](https://user-images.githubusercontent.com/32148199/80049520-7a296100-84e9-11ea-9be5-b0934db478c7.png)
