### PR TITLE
Correção: categorias em destaque da home responsivas

### DIFF
--- a/src/pages/Home/style.scss
+++ b/src/pages/Home/style.scss
@@ -36,6 +36,11 @@
     width: 100%;
     margin: 30px 0px 60px 30px;
 
+    @media (max-width: 425px) {
+      margin: 10px 25px 20px 25px;
+      overflow-x: auto;
+    }
+
     .card-content {
       display: flex;
       flex-direction: column;
@@ -91,58 +96,4 @@
   .check-icon {
     color: #009500;
   }
-}
-
-.home-card{
-  display: flex;
-  justify-content: start;
-  align-items: center;
-  width: 100%;
-  margin: 30px 0px 60px 30px;
-}
-.home-card .card-content{
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  margin: 0px 15px;
-}
-.home-card .card-content span{
-  margin-top: 10px;
-}
-.home-card .card-content .card-img{
-  width: 110px;
-  height: 110px;
-  overflow: hidden;
-  border-radius: 100px;
-}
-
-.home-card .card-content .card-img img{
-  width: 100%;
-  height: 100%;
-  -webkit-transition: -webkit-transform .5s ease;
-  transition: transform .5s ease;
-}
-
-.home-card .card-content .card-img:hover img{
-  -webkit-transform: scale(1.1);
-  transform: scale(1.1);
-}
-
-.producers-content{
-  background-color: #f8f8f8;
-  padding: 15px 0px 40px 0px;
-}
-.producers-content .titulo-content{
-  text-align: center;
-}
-
-.communication-content{
-  background-color: #6597EB ;
-  padding: 20px 0px 30px 0px;
-}
-.communication-content .titulo{
-  font-size: 25px;
-  color: #fff;
-  text-align: center;
 }


### PR DESCRIPTION
# Título do PR

Correção: categorias em destaque da home responsivas

## Descrição do PR

- Ajustei os cards das categorias em destaque para ficarem responsivos em telas mobile (menores que 425px)

## Capturas de Tela

- Antes

![antes](https://user-images.githubusercontent.com/32148199/80050436-f8870280-84eb-11ea-9de4-44b3f8a84af4.png)

- Depois

![depois 1](https://user-images.githubusercontent.com/32148199/80050442-fd4bb680-84eb-11ea-87ea-bedbd8381149.png)

![Sharing-Talks](https://user-images.githubusercontent.com/32148199/80050509-2bc99180-84ec-11ea-8ceb-e6b17917bc54.gif)

