### PR TITLE
Adicionar botão de nova palestra na lista de palestras

### DIFF
--- a/src/pages/Lectures/LecturesList.js
+++ b/src/pages/Lectures/LecturesList.js
@@ -84,8 +84,14 @@ const LecturesList = () => {
       { lectures.length > 0 ?
         (<>
           <Header text="Minhas palestras" />
-          <Row justify="end" className='row-table'>
-            <Button type='default'>
+          <Row justify="space-between" className='row-table'>
+            <Button
+              type='default'
+              className='btn-outline'
+              onClick={() => history.push('/lectures/form')}>
+                Cadastrar uma nova palestra
+            </Button>
+            <Button type='default' className='btn-outline'>
               <Link to='/download-lectures'><span>Faça o download de suas palestras!</span></Link>
             </Button>
           </Row>


### PR DESCRIPTION
# Título do PR

Adicionar botão de nova palestra na lista de palestras

## Descrição do PR

- Adicionei o botão para cadastras novas palestras na lista de palestras

## Capturas de Tela

- Antes

![antes](https://user-images.githubusercontent.com/32148199/80168631-b7f5ba80-85b9-11ea-862f-749e130fb9f8.png)

- Depois

![depois](https://user-images.githubusercontent.com/32148199/80168637-bfb55f00-85b9-11ea-8e4f-a822ef22c855.png)

## Issue do repo

Issue #222 