### PR TITLE
Filtrando palestras pelo id do evento

### DIFF
--- a/src/pages/Submissions/SubmissionInfo.js
+++ b/src/pages/Submissions/SubmissionInfo.js
@@ -24,7 +24,7 @@ const SubmissionInfo = ({ lecture, footerCard }) => {
                 <Col>
                   <Space direction='vertical'>
                     <Space>
-                      <Avatar size={50} src={lecture.uploadedImage && lecture.uploadedImage} ><FontAwesomeIcon icon={faUser} /></Avatar>
+                      <Avatar size={50} src={lecture.userPicture && lecture.userPicture} ><FontAwesomeIcon icon={faUser} /></Avatar>
                       <Item>
                         {lecture.name ? `${lecture.name}` : 'Sem dados'}
                       </Item>

--- a/src/pages/Submissions/SubmissionsPending.js
+++ b/src/pages/Submissions/SubmissionsPending.js
@@ -1,6 +1,7 @@
 import React, { useState, useRef } from 'react'
 import { Row, Col, Button, Carousel, Space } from 'antd'
 import { LeftOutlined, RightOutlined } from '@ant-design/icons'
+import { getEnvironment } from './../../utils/environment';
 import Email from '../../utils/Email/Email'
 import Header from './../../components/Header'
 import SubmissionInfo from './SubmissionInfo'
@@ -17,7 +18,7 @@ const settings = {
   accessibility: false
 }
 
-const environment = 'http://localhost:3001'
+const environment = getEnvironment();
 
 const SubmissionsPending = ({ lectures, handleUpdateLecture }) => {
   const [lecturesPending, setLecturesPending] = useState(lectures)

--- a/src/pages/Submissions/index.js
+++ b/src/pages/Submissions/index.js
@@ -26,12 +26,11 @@ const Submissions = () => {
   }, [eventId])
 
   const getLectures = () => {
-    fetch(`${environment}/lectures`)
+    fetch(`${environment}/lectures?eventId=${eventId}`)
       .then(res => res.json())
       .then(response => {
-        let lecturesById = response.filter(lecture => lecture.eventId.string === eventId.string)
-        setAprovadas(lecturesById.filter(lecture => lecture.status === 'APROVADA'))
-        setLecturesPending(lecturesById.filter(lecture => lecture.status === 'EM ANÁLISE'))
+        setAprovadas(response.filter(lecture => lecture.status === 'APROVADA'))
+        setLecturesPending(response.filter(lecture => lecture.status === 'EM ANÁLISE'))
       })
       .catch(err => console.error(err, 'Nenhuma palestra por aqui!'))
   }

--- a/src/pages/Submissions/submissionDetails.js
+++ b/src/pages/Submissions/submissionDetails.js
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from 'react'
 import { useParams } from 'react-router'
+import { getEnvironment } from '../../utils/environment'
 import Header from '../../components/Header'
 import SubmissionInfo from './SubmissionInfo'
 import './style.scss'
 
-const environment = 'http://localhost:3001'
+const environment = getEnvironment()
 const SubmissionInAnalysis = () => {
   let { submissionId } = useParams()
   const [lecture, setLecture] = useState([])


### PR DESCRIPTION
Palestras de outros eventos aparecendo na listagem

## Descrição do PR

Palestras de outros eventos estavam aparecendo na página do evento

## Capturas de Tela

![image](https://user-images.githubusercontent.com/33610283/80218966-46008e00-8618-11ea-8e31-3f47818f6d03.png)


## Issue do repo

#231 

## Casos de Teste Pensados

Criar uma nova palestra e ver se ela aparece somente na tela do evento certo. Aprovar e/ou reprovar e verificar se a listagem continua certa para o evento em questão

## Descrição técnica da solução

Filtrei mandando o parâmetro do evento pela própria url

## Dilemas, dúvidas e dívidas

- Também mudei as variáveis do environment pra usar a função getEnvironment() do utils, assim fica mais fácil se precisar trocar a porta 3001, só precisará trocar em um lugar
- E corrigi a foto do usuário nos detalhes da palestra, que estava com o nome errado, estava como lecture.uploadedImage e não lecture.userPicture
