### PR TITLE
Imagem default para eventos sem foto

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -86,3 +86,25 @@ h3 {
     white-space: normal;
   }
 }
+
+.event-img {
+  align-items: center;
+  background-color: #f3f3f3;
+  color: #a3a3a3;
+  display: flex;
+  font-size: 2em;
+  height: 150px;
+  justify-content: center;
+  margin: 0;
+  overflow: hidden;
+  width: 100%;
+}
+
+.event-details {
+  height: 4em;
+  width: 5em;
+
+  .fa-image {
+    margin: 0;
+  }
+}

--- a/src/pages/Events/Event.js
+++ b/src/pages/Events/Event.js
@@ -48,7 +48,9 @@ const Event = ({ event }) => {
               <Col xs={{ span: 24 }} md={{ span: 6 }} style={{marginRight:'4.167%'}}>
                 <Space direction="vertical" size={8} style={{ width: '100%', height: '100%' }}>
                   <span>Organizado por {event.organizer}</span>
-                  <img src={event.uploadedImage} alt={`Lôgo do evento ${event.event}`} width="100%" />
+                  { event.uploadedImage &&
+                    <img src={event.uploadedImage} alt='Imagem do evento' width='100%' height='100%' />
+                  }
                   {
                     isOwnerEvent ? (
                       <Button type="link" onClick={() => copyToCliboard()} style={{ padding: 0 }}>

--- a/src/pages/Events/Event.js
+++ b/src/pages/Events/Event.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { useParams, useHistory } from 'react-router'
 import { Row, Col, Tag, Button, Space } from 'antd'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faLink } from '@fortawesome/free-solid-svg-icons'
+import { faLink, faImage } from '@fortawesome/free-solid-svg-icons'
 import { getUserIsOwner } from './../../utils/getUserIsOwner '
 import { copyToCliboard } from '../../utils/copyToCliboard'
 import Header from './../../components/Header'
@@ -48,9 +48,12 @@ const Event = ({ event }) => {
               <Col xs={{ span: 24 }} md={{ span: 6 }} style={{marginRight:'4.167%'}}>
                 <Space direction="vertical" size={8} style={{ width: '100%', height: '100%' }}>
                   <span>Organizado por {event.organizer}</span>
-                  { event.uploadedImage &&
-                    <img src={event.uploadedImage} alt='Imagem do evento' width='100%' height='100%' />
-                  }
+                  <div className='event-img event-details'>
+                    { event.uploadedImage ?
+                      (<img src={event.uploadedImage} alt='Imagem do evento' width='100%' height='100%' />) :
+                      (<FontAwesomeIcon icon={faImage} />)
+                    }
+                  </div>
                   {
                     isOwnerEvent ? (
                       <Button type="link" onClick={() => copyToCliboard()} style={{ padding: 0 }}>

--- a/src/pages/Home/CardEvent.js
+++ b/src/pages/Home/CardEvent.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import { Card, Typography, Space } from 'antd'
 import { Link } from 'react-router-dom'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faImage } from '@fortawesome/free-solid-svg-icons'
 
 const { Text } = Typography;
 
@@ -10,14 +12,17 @@ const CardEvent = ({ event }) => {
     <Card actions={[<Link to={`/events/${event.id}`} >Submeta sua palestra</Link>]} >
 
 
-      <Space direction="vertical">
-        <div style={{width: '100%',height: '150px',overflow: 'hidden'}}>
-          <img src={event.uploadedImage} alt="" width="100%" style={{ margin: '0' }} />
+      <Space direction='vertical' style={{width: '100%'}}>
+        <div className='event-img'>
+          { event.uploadedImage ?
+            (<img src={event.uploadedImage} alt='Imagem do evento' width='100%' height='100%' />) :
+            (<FontAwesomeIcon icon={faImage} />)
+          }
         </div>
         <Text strong>{event.event}</Text>
-        <Space direction="vertical" size={0}>
-          <Text type="secondary">{event.schedule}</Text>
-          <Text type="secondary">{event.local}</Text>
+        <Space direction='vertical' size={0}>
+          <Text type='secondary'>{event.schedule}</Text>
+          <Text type='secondary'>{event.local}</Text>
         </Space>
       </Space>
     </Card>

--- a/src/pages/Home/CardEvent.js
+++ b/src/pages/Home/CardEvent.js
@@ -10,8 +10,6 @@ const CardEvent = ({ event }) => {
 
   return (
     <Card actions={[<Link to={`/events/${event.id}`} >Submeta sua palestra</Link>]} >
-
-
       <Space direction='vertical' style={{width: '100%'}}>
         <div className='event-img'>
           { event.uploadedImage ?

--- a/src/pages/Home/style.scss
+++ b/src/pages/Home/style.scss
@@ -102,3 +102,16 @@
     }
   }
 }
+
+.event-img {
+  align-items: center;
+  background-color: #f3f3f3;
+  color: #a3a3a3;
+  display: flex;
+  font-size: 2em;
+  height: 150px;
+  justify-content: center;
+  margin: 0;
+  overflow: hidden;
+  width: 100%;
+}

--- a/src/pages/Home/style.scss
+++ b/src/pages/Home/style.scss
@@ -102,16 +102,3 @@
     }
   }
 }
-
-.event-img {
-  align-items: center;
-  background-color: #f3f3f3;
-  color: #a3a3a3;
-  display: flex;
-  font-size: 2em;
-  height: 150px;
-  justify-content: center;
-  margin: 0;
-  overflow: hidden;
-  width: 100%;
-}


### PR DESCRIPTION
# Título do PR

Imagem default para eventos sem foto

## Descrição do PR

- Adicionei imagem default nos cards dos eventos sem foto
- Adicionei uma verificação na página de detalhes do evento para não quebrar quando o evento não tem foto

## Capturas de Tela

- Card

![depois](https://user-images.githubusercontent.com/32148199/80325755-d56e9280-880c-11ea-9264-84e85b867015.png)

- Detalhes do evento (antes)

![antes](https://user-images.githubusercontent.com/32148199/80325769-e0c1be00-880c-11ea-8024-aec8831442cd.png)

- Detalhes do evento (depois)

![depois 2](https://user-images.githubusercontent.com/32148199/80325777-ea4b2600-880c-11ea-8099-996a1a333840.png)

## Issue do repo

Issue #239 